### PR TITLE
Add configurable configMap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
 stages:
   - build and test
   - name: push to quay.io
-    if: branch = master
+    if: branch = master AND type != pull_request
 after_success:
 - echo 'Build succeeded, Elasticsearch operator is running on minikube, and unit/integration
   tests pass'

--- a/pkg/apis/elasticsearch/v1alpha1/types.go
+++ b/pkg/apis/elasticsearch/v1alpha1/types.go
@@ -72,6 +72,7 @@ type ElasticsearchSpec struct {
 	Spec               ElasticsearchNodeSpec `json:"nodeSpec"`
 	Secure             ElasticsearchSecure   `json:"securityConfig"`
 	ServiceAccountName string                `json:"serviceAccountName,omitempty"`
+	ConfigMapName      string                `json:"configMapName,omitempty"`
 }
 
 // ElasticsearchNodeSpec represents configuration of an individual Elasticsearch node

--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -26,9 +26,9 @@ type nodeState struct {
 }
 
 // CreateOrUpdateElasticsearchCluster creates an Elasticsearch deployment
-func CreateOrUpdateElasticsearchCluster(dpl *v1alpha1.Elasticsearch, configMapName string) error {
+func CreateOrUpdateElasticsearchCluster(dpl *v1alpha1.Elasticsearch, configMapName, serviceAccountName string) error {
 
-	cState, err := NewClusterState(dpl, configMapName)
+	cState, err := NewClusterState(dpl, configMapName, serviceAccountName)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func CreateOrUpdateElasticsearchCluster(dpl *v1alpha1.Elasticsearch, configMapNa
 	return nil
 }
 
-func NewClusterState(dpl *v1alpha1.Elasticsearch, configMapName string) (clusterState, error) {
+func NewClusterState(dpl *v1alpha1.Elasticsearch, configMapName, serviceAccountName string) (clusterState, error) {
 	nodes := []*nodeState{}
 	cState := clusterState{
 		Nodes: nodes,
@@ -74,7 +74,7 @@ func NewClusterState(dpl *v1alpha1.Elasticsearch, configMapName string) (cluster
 	for nodeNum, node := range dpl.Spec.Nodes {
 
 		for i = 1; i <= node.Replicas; i++ {
-			nodeCfg, err := constructNodeSpec(dpl, node, configMapName, int32(nodeNum), i)
+			nodeCfg, err := constructNodeSpec(dpl, node, configMapName, serviceAccountName, int32(nodeNum), i)
 			if err != nil {
 				return cState, fmt.Errorf("Unable to construct ES node config %v", err)
 			}

--- a/pkg/k8shandler/cluster.go
+++ b/pkg/k8shandler/cluster.go
@@ -26,9 +26,9 @@ type nodeState struct {
 }
 
 // CreateOrUpdateElasticsearchCluster creates an Elasticsearch deployment
-func CreateOrUpdateElasticsearchCluster(dpl *v1alpha1.Elasticsearch) error {
+func CreateOrUpdateElasticsearchCluster(dpl *v1alpha1.Elasticsearch, configMapName string) error {
 
-	cState, err := NewClusterState(dpl)
+	cState, err := NewClusterState(dpl, configMapName)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func CreateOrUpdateElasticsearchCluster(dpl *v1alpha1.Elasticsearch) error {
 	return nil
 }
 
-func NewClusterState(dpl *v1alpha1.Elasticsearch) (clusterState, error) {
+func NewClusterState(dpl *v1alpha1.Elasticsearch, configMapName string) (clusterState, error) {
 	nodes := []*nodeState{}
 	cState := clusterState{
 		Nodes: nodes,
@@ -74,7 +74,7 @@ func NewClusterState(dpl *v1alpha1.Elasticsearch) (clusterState, error) {
 	for nodeNum, node := range dpl.Spec.Nodes {
 
 		for i = 1; i <= node.Replicas; i++ {
-			nodeCfg, err := constructNodeSpec(dpl, node, int32(nodeNum), i)
+			nodeCfg, err := constructNodeSpec(dpl, node, configMapName, int32(nodeNum), i)
 			if err != nil {
 				return cState, fmt.Errorf("Unable to construct ES node config %v", err)
 			}

--- a/pkg/k8shandler/elasticsearchnode.go
+++ b/pkg/k8shandler/elasticsearchnode.go
@@ -23,9 +23,10 @@ type elasticsearchNode struct {
 	NodeNum             int32
 	ReplicaNum          int32
 	ServiceAccountName  string
+	ConfigMapName       string
 }
 
-func constructNodeSpec(dpl *v1alpha1.Elasticsearch, esNode v1alpha1.ElasticsearchNode, nodeNum int32, replicaNum int32) (elasticsearchNode, error) {
+func constructNodeSpec(dpl *v1alpha1.Elasticsearch, esNode v1alpha1.ElasticsearchNode, configMapName string, nodeNum int32, replicaNum int32) (elasticsearchNode, error) {
 	nodeCfg := elasticsearchNode{
 		ClusterName:         dpl.Name,
 		Namespace:           dpl.Namespace,
@@ -35,6 +36,7 @@ func constructNodeSpec(dpl *v1alpha1.Elasticsearch, esNode v1alpha1.Elasticsearc
 		NodeNum:             nodeNum,
 		ReplicaNum:          replicaNum,
 		ServiceAccountName:  dpl.Spec.ServiceAccountName,
+		ConfigMapName:       configMapName,
 	}
 	deployName, err := constructDeployName(dpl.Name, esNode.Roles, nodeNum, replicaNum)
 	if err != nil {

--- a/pkg/k8shandler/elasticsearchnode.go
+++ b/pkg/k8shandler/elasticsearchnode.go
@@ -26,7 +26,7 @@ type elasticsearchNode struct {
 	ConfigMapName       string
 }
 
-func constructNodeSpec(dpl *v1alpha1.Elasticsearch, esNode v1alpha1.ElasticsearchNode, configMapName string, nodeNum int32, replicaNum int32) (elasticsearchNode, error) {
+func constructNodeSpec(dpl *v1alpha1.Elasticsearch, esNode v1alpha1.ElasticsearchNode, configMapName, serviceAccountName string, nodeNum int32, replicaNum int32) (elasticsearchNode, error) {
 	nodeCfg := elasticsearchNode{
 		ClusterName:         dpl.Name,
 		Namespace:           dpl.Namespace,
@@ -35,7 +35,7 @@ func constructNodeSpec(dpl *v1alpha1.Elasticsearch, esNode v1alpha1.Elasticsearc
 		ElasticsearchSecure: dpl.Spec.Secure,
 		NodeNum:             nodeNum,
 		ReplicaNum:          replicaNum,
-		ServiceAccountName:  dpl.Spec.ServiceAccountName,
+		ServiceAccountName:  serviceAccountName,
 		ConfigMapName:       configMapName,
 	}
 	deployName, err := constructDeployName(dpl.Name, esNode.Roles, nodeNum, replicaNum)

--- a/pkg/k8shandler/nodehelpers.go
+++ b/pkg/k8shandler/nodehelpers.go
@@ -25,6 +25,7 @@ const (
 	defaultMemoryRequest      = "1Gi"
 	heapDumpLocation          = "/elasticsearch/persistent/heapdump.hprof"
 	promUser                  = "prometheus"
+	defaultCertSecretName     = "logging-elasticsearch"
 )
 
 func getReadinessProbe() v1.Probe {
@@ -308,7 +309,7 @@ func (cfg *elasticsearchNode) getVolumes() []v1.Volume {
 			VolumeSource: v1.VolumeSource{
 				ConfigMap: &v1.ConfigMapVolumeSource{
 					LocalObjectReference: v1.LocalObjectReference{
-						Name: cfg.ClusterName,
+						Name: cfg.ConfigMapName,
 					},
 				},
 			},
@@ -317,7 +318,7 @@ func (cfg *elasticsearchNode) getVolumes() []v1.Volume {
 	if !cfg.ElasticsearchSecure.Disabled {
 		var secretName string
 		if cfg.ElasticsearchSecure.CertificatesSecret == "" {
-			secretName = fmt.Sprintf("%s-certs", cfg.ClusterName)
+			secretName = defaultCertSecretName
 		} else {
 			secretName = cfg.ElasticsearchSecure.CertificatesSecret
 		}

--- a/pkg/k8shandler/serviceaccount.go
+++ b/pkg/k8shandler/serviceaccount.go
@@ -16,7 +16,7 @@ const (
 )
 
 // CreateOrUpdateServiceAccount ensures the existence of the serviceaccount for Elasticsearch cluster
-func CreateOrUpdateServiceAccount(dpl *v1alpha1.Elasticsearch) error {
+func CreateOrUpdateServiceAccount(dpl *v1alpha1.Elasticsearch) (string, error) {
 	// In case no serviceaccount is specified in the spec, we'll use the default name for service account
 	var serviceAccountName string
 	if dpl.Spec.ServiceAccountName == "" {
@@ -29,10 +29,10 @@ func CreateOrUpdateServiceAccount(dpl *v1alpha1.Elasticsearch) error {
 
 	err := createOrUpdateServiceAccount(serviceAccountName, dpl.Namespace, owner)
 	if err != nil {
-		return fmt.Errorf("Failure creating ServiceAccount %v", err)
+		return serviceAccountName, fmt.Errorf("Failure creating ServiceAccount %v", err)
 	}
 
-	return nil
+	return serviceAccountName, nil
 }
 
 func createOrUpdateServiceAccount(serviceAccountName, namespace string, owner metav1.OwnerReference) error {

--- a/pkg/k8shandler/serviceaccount.go
+++ b/pkg/k8shandler/serviceaccount.go
@@ -11,16 +11,23 @@ import (
 	v1alpha1 "github.com/t0ffel/elasticsearch-operator/pkg/apis/elasticsearch/v1alpha1"
 )
 
+const (
+	defaultServiceAccountName = "aggregated-logging-elasticsearch"
+)
+
 // CreateOrUpdateServiceAccount ensures the existence of the serviceaccount for Elasticsearch cluster
 func CreateOrUpdateServiceAccount(dpl *v1alpha1.Elasticsearch) error {
-	// In case no serviceaccount is specified in the spec, we'll use the namespace's default service account
+	// In case no serviceaccount is specified in the spec, we'll use the default name for service account
+	var serviceAccountName string
 	if dpl.Spec.ServiceAccountName == "" {
-		return nil
+		serviceAccountName = defaultServiceAccountName
+	} else {
+		serviceAccountName = dpl.Spec.ServiceAccountName
 	}
 
 	owner := asOwner(dpl)
 
-	err := createOrUpdateServiceAccount(dpl.Spec.ServiceAccountName, dpl.Namespace, owner)
+	err := createOrUpdateServiceAccount(serviceAccountName, dpl.Namespace, owner)
 	if err != nil {
 		return fmt.Errorf("Failure creating ServiceAccount %v", err)
 	}

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -48,7 +48,7 @@ func Reconcile(es *v1alpha1.Elasticsearch) (err error) {
 	}
 
 	// Ensure existence of services
-	err = k8shandler.CreateOrUpdateConfigMaps(es)
+	configMapName, err := k8shandler.CreateOrUpdateConfigMaps(es)
 	if err != nil {
 		return fmt.Errorf("Failed to reconcile ConfigMaps for Elasticsearch cluster: %v", err)
 	}
@@ -56,7 +56,7 @@ func Reconcile(es *v1alpha1.Elasticsearch) (err error) {
 	// TODO: Ensure existence of storage?
 
 	// Ensure Elasticsearch cluster itself is up to spec
-	err = k8shandler.CreateOrUpdateElasticsearchCluster(es)
+	err = k8shandler.CreateOrUpdateElasticsearchCluster(es, configMapName)
 	if err != nil {
 		return fmt.Errorf("Failed to reconcile Elasticsearch deployment spec: %v", err)
 	}

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -42,7 +42,7 @@ func Reconcile(es *v1alpha1.Elasticsearch) (err error) {
 	}
 
 	// Ensure existence of servicesaccount
-	err = k8shandler.CreateOrUpdateServiceAccount(es)
+	serviceAccountName, err := k8shandler.CreateOrUpdateServiceAccount(es)
 	if err != nil {
 		return fmt.Errorf("Failed to reconcile ServiceAccount for Elasticsearch cluster: %v", err)
 	}
@@ -56,7 +56,7 @@ func Reconcile(es *v1alpha1.Elasticsearch) (err error) {
 	// TODO: Ensure existence of storage?
 
 	// Ensure Elasticsearch cluster itself is up to spec
-	err = k8shandler.CreateOrUpdateElasticsearchCluster(es, configMapName)
+	err = k8shandler.CreateOrUpdateElasticsearchCluster(es, configMapName, serviceAccountName)
 	if err != nil {
 		return fmt.Errorf("Failed to reconcile Elasticsearch deployment spec: %v", err)
 	}


### PR DESCRIPTION
configMap for Elasticsearch can be configured via .spec.configMapName parameter.
If not specified, Elasticsearch will construct or use existing configmap
named logging-elasticsearch.

Default name for the secret which carries the certificates is changed to
logging-elasticsearch.